### PR TITLE
Ensure text search runs regardless of filter sets

### DIFF
--- a/adv/adv.html
+++ b/adv/adv.html
@@ -941,10 +941,7 @@
                 });
 
                 // Zwischen Filter-Sets verknüpfen
-                if (filterResults.length === 0) return true;
-                if (filterResults.length === 1) return filterResults[0];
-
-                let result = filterResults[0];
+                let result = filterResults.length === 0 ? true : filterResults[0];
                 for (let i = 1; i < filterResults.length; i++) {
                     const logic = filterSets[i-1]?.betweenLogic || 'AND';
                     if (logic === 'AND') {


### PR DESCRIPTION
## Summary
- evaluate text search even when no or single filter set present by replacing early returns in `applyFilters`

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_689a50eedfdc83258e8528a19cc262bd